### PR TITLE
Added badges for Travis and Coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Travis](https://api.travis-ci.org/CubeBrowser/cube-explorer.svg?branch=master)](https://travis-ci.org/CubeBrowser/cube-explorer)
+[![Coveralls](https://img.shields.io/coveralls/CubeBrowser/cube-explorer.svg)](https://coveralls.io/github/CubeBrowser/cube-explorer)
 # cube-explorer
 
 Web browser based exploration of https://github.com/SciTools/iris cubes.


### PR DESCRIPTION
This PR simply adds badges for Travis and Coveralls to the README. 

Right now the build status is unknown but will updated the PR is merged and then the badges should go green!
