### PR TITLE
Added property to return iris Cube from HoloCube if available

### DIFF
--- a/holocube/element/cube.py
+++ b/holocube/element/cube.py
@@ -26,6 +26,14 @@ class HoloCube(Table):
     group = param.String(default='HoloCube')
 
     @property
+    def cube(self):
+        " Returns the underlying iris Cube if available. "
+        if issubclass(self.interface, CubeConversion):
+            return self.data
+        else:
+            return None
+
+    @property
     def to(self):
         """
         Property to create a conversion table with methods to convert


### PR DESCRIPTION
This PR adds a property to alias the data attribute following the suggestion in #19. Note that there are some issues with this proposal. Since we now use a HoloViews interface class to wrap cube data, all regular HoloViews Elements can now contain cubes and all HoloCube Elements can theoretically contain non-cube data. This means that even though a lot of Elements support cube data only the ones that inherit from `HoloCube` will have the `cube` property. It is also possible to construct one of the geographic Elements without an iris Cube in which case the `cube` property returns None.

Given these caveats I'm not entirely sure how useful this property is in practice. It may be worth it to provide an easy way to convert other data formats to cubes so this property can always return something.
