### PR TITLE
Switched HoloCube baseclass from Table to Columns

### DIFF
--- a/holocube/element/cube.py
+++ b/holocube/element/cube.py
@@ -3,16 +3,16 @@ import numpy as np
 
 import param
 from holoviews.core.dimension import Dimension
-from holoviews.core.data import DataColumns, GridColumns
+from holoviews.core.data import Columns, DataColumns, GridColumns
 from holoviews.core.ndmapping import (NdMapping, item_check,
                                       sorted_context)
 from holoviews.core.spaces import HoloMap
-from holoviews.element.tabular import Table, TableConversion
+from holoviews.element.tabular import TableConversion
 from . import util
 
 
 
-class HoloCube(Table):
+class HoloCube(Columns):
     """
     The HoloCube Element provides an interface to wrap and display
     :class:`Iris.cube.Cube` objects. The Cube automatically
@@ -21,7 +21,7 @@ class HoloCube(Table):
     and slicing the data.
     """
 
-    datatype = param.List(default=Table.datatype+['cube'])
+    datatype = param.List(default=Columns.datatype+['cube'])
 
     group = param.String(default='HoloCube')
 
@@ -71,12 +71,13 @@ class CubeConversion(TableConversion):
 
 class CubeInterface(GridColumns):
     """
-    The CubeInterface provides allows HoloViews to interact
-    with iris Cube data. When passing an iris Cube to a
-    HoloViews Element the init method will infer the
-    dimensions of the HoloCube from its coordinates.
-    Currently the interface only provides the basic methods
-    required for HoloViews to work with an object.
+    The CubeInterface provides allows HoloViews
+    to interact with iris Cube data. When passing
+    an iris Cube to a HoloViews Element the init
+    method will infer the dimensions of the HoloCube
+    from its coordinates. Currently the interface
+    only provides the basic methods required for
+    HoloViews to work with an object.
     """
 
     types = (iris.cube.Cube,)


### PR DESCRIPTION
This simply changes `HoloCube` to inherit from `Columns` rather than `Table`. We will likely rename the `Columns` baseclass in future to denote the generality of the data structure but in the meantime it is a more appropriate baseclass than `Table` since the `Table` type has some unique handling applied to it in the plotting code.
