### PR TITLE
Added general AnnotationPlot and Text Element

### DIFF
--- a/holocube/__init__.py
+++ b/holocube/__init__.py
@@ -1,4 +1,4 @@
 from .element import (GeoElement, HoloCube, GeoFeature, # noqa (API import)
-                      GeoTiles, WMTS, Contours,
+                      GeoTiles, WMTS, Contours, Text,
                       Image, Points)
 from . import plotting                              # noqa (API import)

--- a/holocube/element/__init__.py
+++ b/holocube/element/__init__.py
@@ -1,3 +1,3 @@
 from .cube import HoloCube                              # noqa (API import)
-from .geo import (GeoElement, GeoFeature, GeoTiles, # noqa (API import)
-                  WMTS, Points, Image, Contours)
+from .geo import (GeoElement, GeoFeature, GeoTiles,     # noqa (API import)
+                  WMTS, Points, Image, Text, Contours)

--- a/holocube/element/geo.py
+++ b/holocube/element/geo.py
@@ -6,6 +6,7 @@ from cartopy.feature import Feature
 from cartopy.io.img_tiles import GoogleTiles
 from holoviews.core import Element2D, Dimension
 from holoviews.core import util
+from holoviews.element import Text as HVText
 
 from .cube import HoloCube
 
@@ -130,3 +131,10 @@ class Image(GeoElement, HoloCube):
     vdims = param.List(default=[Dimension('z')], bounds=(1, 1))
 
     group = param.String(default='Image')
+
+
+class Text(HVText, GeoElement):
+    """
+    An annotation containing some text at an x, y coordinate
+    along with a coordinate reference system.
+    """


### PR DESCRIPTION
Adds an Element type to place Text annotations at a coordinate specified in an associated coordinate reference system. The GeoAnnotationPlot baseclass passes the coordinate reference system to the subclasses, which can apply the transform.

Here's an example in action, the text coordinates can be supplied in supported coordinate reference system:

``` python
tiles = MapQuestOSM()
hc.GeoTiles(tiles)(plot=dict(projection=tiles.crs, zoom=14)) *\
hc.Text(531738., 180690., 'Some text on the Thames', crs=crs.OSGB()) *\
hc.Points(tube_locations(), crs=crs.OSGB())(style=dict(color='r', s=100, marker=concentric_circle)) *\
hc.Points(tube_locations(), crs=crs.OSGB())(style=dict(color='b', s=100, marker=rectangle))
```

![image](https://cloud.githubusercontent.com/assets/1550771/14088700/eb20dc8a-f528-11e5-9edc-ba154e2ad554.png)
