### PR TITLE
Avoid loading and caching cube data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
   - pip install coveralls
   - pip install git+https://github.com/ioam/holoviews.git
   - conda install -c scitools iris
+  - conda install -c scitools mo_pack
   - python setup.py install
 
 script:

--- a/holocube/element/cube.py
+++ b/holocube/element/cube.py
@@ -1,3 +1,4 @@
+from itertools import product
 import iris
 import numpy as np
 
@@ -151,12 +152,17 @@ class CubeInterface(GridColumns):
         """
         if not isinstance(dims, list): dims = [dims]
         dims = [holocube.get_dimension(d) for d in dims]
+        constraints = [d.name for d in dims]
         slice_dims = [d for d in holocube.kdims if d not in dims]
+        unique_coords = product(*[cls.values(holocube, d, expanded=False)
+                                 for d in dims])
         data = []
-        for cube in holocube.data.slices([d.name for d in slice_dims]):
-            key = tuple(cube.coord(kd.name).points[0] for kd in dims)
-            data.append((key, holocube.clone(cube, new_type=group_type,
-                                             **dict(kwargs, kdims=slice_dims))))
+        for key in unique_coords:
+            constraint = iris.Constraint(**dict(zip(constraints, key)))
+            cube = holocube.clone(holocube.data.extract(constraint),
+                                  new_type=group_type,
+                                  **dict(kwargs, kdims=slice_dims))
+            data.append((key, cube))
         if issubclass(container_type, NdMapping):
             with item_check(False), sorted_context(False):
                 return container_type(data, kdims=dims)

--- a/holocube/element/cube.py
+++ b/holocube/element/cube.py
@@ -122,7 +122,7 @@ class CubeInterface(GridColumns):
         """
         dim = holocube.get_dimension(dim)
         if dim in holocube.vdims:
-            data = holocube.data.data
+            data = holocube.data.copy().data
         elif expanded:
             idx = holocube.get_dimension_index(dim)
             data = util.cartesian_product([holocube.data.coords(d.name)[0].points

--- a/holocube/plotting/__init__.py
+++ b/holocube/plotting/__init__.py
@@ -47,7 +47,7 @@ class GeoContourPlot(GeoPlot, ColorbarPlot):
     style_opts = ['antialiased', 'alpha', 'cmap']
     
     def get_data(self, element, ranges, style):
-        args = (element.data,)
+        args = (element.data.copy(),)
         if isinstance(self.levels, int):
             args += (self.levels,)
         else:
@@ -71,7 +71,7 @@ class GeoImagePlot(GeoPlot, ColorbarPlot):
     def get_data(self, element, ranges, style):
         self._norm_kwargs(element, ranges, style, element.vdims[0])
         style.pop('interpolation')
-        return (element.data,), style, {}
+        return (element.data.copy(),), style, {}
     
     def init_artists(self, ax, plot_args, plot_kwargs):
         return {'artist': iplt.pcolormesh(*plot_args, axes=ax, **plot_kwargs)}


### PR DESCRIPTION
Includes two fixes to avoid loading and caching cube data. The first avoids using the `slices` method in favor of the `extract` method since the former loads the data into memory. The second change uses copy, whereever the code tries to access the cube data. This should address #16.
