### PR TITLE
Limiting coverage reporting to holocube package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - python setup.py install
 
 script:
-  - nosetests --with-doctest --with-coverage
+  - nosetests --with-doctest --with-coverage --cover-package=holocube
   - flake8 --ignore=E,W .
 
 after_success: coveralls


### PR DESCRIPTION
This PR addresses issue #26 by only generating a coverage report for the holocube packages.
