### PR TITLE
Optimizations for updating Image and GeoFeature plots

### DIFF
--- a/holocube/plotting/__init__.py
+++ b/holocube/plotting/__init__.py
@@ -78,6 +78,15 @@ class GeoImagePlot(GeoPlot, ColorbarPlot):
     def init_artists(self, ax, plot_args, plot_kwargs):
         return {'artist': iplt.pcolormesh(*plot_args, axes=ax, **plot_kwargs)}
 
+    def update_handles(self, key, axis, element, ranges, style):
+        cmesh = self.handles['artist']
+        data, style, axis_kwargs = self.get_data(element, ranges, style)
+        cmesh.set_array(data[-1].data.flatten())
+        cmesh.set_clim((style['vmin'], style['vmax']))
+        if 'norm' in style:
+            cmesh.norm = style['norm']
+
+
 
 class GeoPointPlot(GeoPlot, PointPlot):
     """
@@ -114,6 +123,9 @@ class GeoFeaturePlot(GeoPlot):
 
     def init_artists(self, ax, plot_args, plot_kwargs):
         return {'artist': ax.add_feature(*plot_args, **plot_kwargs)}
+
+    def update_handles(self, key, axis, element, ranges, style):
+        pass
 
 
 class WMTSPlot(GeoPlot):


### PR DESCRIPTION
Rather than redrawing a `pcolormesh` on each frame the `GeoImagePlot` now updates the artist directly. This only works because the extents of the colormesh shouldn't change across a single cube. To be completely safe I could request a full redraw if the lat/lon coordinates change but I don't think it's necessary. I've also avoided updating the the `GeoFeature` on each frame as it is expected to be static.

If someone thinks either of these assumptions isn't valid I could check more explicitly if things are unchanged and revert to the old behavior if they do not hold.
