### PR TITLE
Cube transpose bug fix

### DIFF
--- a/holocube/element/cube.py
+++ b/holocube/element/cube.py
@@ -124,6 +124,10 @@ class CubeInterface(GridColumns):
         dim = holocube.get_dimension(dim)
         if dim in holocube.vdims:
             data = holocube.data.copy().data
+            coord_names = [c.name() for c in holocube.data.dim_coords
+                           if c.name() in holocube.kdims]
+            dim_inds = [coord_names.index(d.name) for d in holocube.kdims]
+            data = data.transpose(dim_inds)
         elif expanded:
             idx = holocube.get_dimension_index(dim)
             data = util.cartesian_product([holocube.data.coords(d.name)[0].points

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -44,9 +44,10 @@ class TestCube(ComparisonTestCase):
     def test_dimension_values_vdim(self):
         cube = HoloCube(self.cube, kdims=['longitude', 'latitude'])
         self.assertEqual(cube.dimension_values('unknown', flat=False),
-                         np.array([[ 0,  1,  2,  3],
-                                   [ 4,  5,  6,  7],
-                                   [ 8,  9, 10, 11]], dtype=np.int32))
+                         np.array([[ 0,  4,  8],
+                                   [ 1,  5,  9],
+                                   [ 2,  6, 10],
+                                   [ 3,  7, 11]], dtype=np.int32))
 
     def test_range_kdim(self):
         cube = HoloCube(self.cube, kdims=['longitude', 'latitude'])


### PR DESCRIPTION
When I switched to using `cube.extract` to apply perform the groupby instead of `cube.slices` that had the side-effect that the resultant cube was not transposed so the values returned by `CubeInterface.values` are in the wrong order. Since transposing requires the data to be in memory we now apply the transpose operation only when returning the values. This means that the order of coordinates in a HoloCube don't have to match the order of dimensions on the HoloCube.
