### PR TITLE
Added support for dynamic groupby

### DIFF
--- a/holocube/element/cube.py
+++ b/holocube/element/cube.py
@@ -7,7 +7,7 @@ from holoviews.core.dimension import Dimension
 from holoviews.core.data import Columns, DataColumns, GridColumns
 from holoviews.core.ndmapping import (NdMapping, item_check,
                                       sorted_context)
-from holoviews.core.spaces import HoloMap
+from holoviews.core.spaces import HoloMap, DynamicMap
 from holoviews.element.tabular import TableConversion
 from . import util
 
@@ -152,11 +152,22 @@ class CubeInterface(GridColumns):
         break up a high-dimensional HoloCube into smaller viewable chunks.
         """
         if not isinstance(dims, list): dims = [dims]
+        dynamic = kwargs.get('dynamic', False)
         dims = [holocube.get_dimension(d) for d in dims]
         constraints = [d.name for d in dims]
         slice_dims = [d for d in holocube.kdims if d not in dims]
+
+        if dynamic:
+            def load_subset(*args):
+                constraint = iris.Constraint(**dict(zip(constraints, args)))
+                return holocube.clone(holocube.data.extract(constraint),
+                                      new_type=group_type,
+                                      **dict(kwargs, kdims=slice_dims))
+            dynamic_dims = [d(values=list(cls.values(holocube, d, False))) for d in dims]
+            return DynamicMap(load_subset, kdims=dynamic_dims)
+
         unique_coords = product(*[cls.values(holocube, d, expanded=False)
-                                 for d in dims])
+                                  for d in dims])
         data = []
         for key in unique_coords:
             constraint = iris.Constraint(**dict(zip(constraints, key)))


### PR DESCRIPTION
The groupby method now supports a `dynamic` argument, which avoids expanding the Cube into individual Elements immediately, instead returning a DynamicMap, which will extract the frames from the original cube on request. This will be much faster for large datasets and can be used like this:

``` python
cubes['specific_humidity'].to.image(['grid_longitude', 'grid_latitude'], dynamic=True)
```

Eventually we can support this at the HoloViews level, but before that can work here we'll have to implement slicing and indexing semantics on the `CubeInterface`.
